### PR TITLE
Remove unused select boxes from forms

### DIFF
--- a/map/templates/map/phototimor_form.html
+++ b/map/templates/map/phototimor_form.html
@@ -93,9 +93,6 @@
   </div>
 </div>
 <script>
-    const path = window.location.pathname.split('/');
-    $("#id_istoriaviazen").val(path[1]);
     document.getElementsByClassName("btn")[0].click();
-    $('option').hide();
 </script>
 {% endblock %}

--- a/map/views.py
+++ b/map/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.core.serializers import serialize
 from django.views.generic.base import TemplateView
 from map.gps_images import ImageMetaData
-from django.views.generic.edit import CreateView, UpdateView, DeleteView
+from django.views.generic.edit import FormView, CreateView, UpdateView, DeleteView
 from .models import Aldeia, Suco, Subdistrict, District, PhotoTimor, Istoriaviazen
 from django.contrib.gis.geos import Point
 from django.urls import reverse_lazy
@@ -118,7 +118,7 @@ class MapView(TemplateView):
 class HatamaViazenView(CreateView):
     template_name = 'map/viajen_form.html'
     model = Istoriaviazen
-    fields = ['title', 'description', 'date', 'creator']
+    fields = ['title', 'description', 'date']
 
     def get_success_url(self):
         return reverse_lazy('photo_viazen', args = (self.object.id,))
@@ -128,6 +128,10 @@ class HatamaViazenView(CreateView):
         context['hatama_viazen'] = _("Add Journey History")
         return context
 
+    def form_valid(self, form):
+        # set the creator of the istoria to the logged in user
+        form.instance.creator = self.request.user
+        return super().form_valid(form)
 
 class PhotoViazenView(CreateView):
     template_name = 'map/phototimor_form.html'

--- a/map/views.py
+++ b/map/views.py
@@ -133,10 +133,11 @@ class HatamaViazenView(CreateView):
         form.instance.creator = self.request.user
         return super().form_valid(form)
 
+
 class PhotoViazenView(CreateView):
     template_name = 'map/phototimor_form.html'
     model = PhotoTimor
-    fields = ['image', 'istoriaviazen']
+    fields = ['image']
 
     def get_success_url(self):
         return reverse_lazy('photo_viazen', args = (self.object.istoriaviazen_id,))
@@ -146,6 +147,11 @@ class PhotoViazenView(CreateView):
         context = super(PhotoViazenView, self).get_context_data(*args, **kwargs)
         context['journey_photos'] = PhotoTimor.objects.filter(istoriaviazen=target)
         return context
+
+    def form_valid(self, form):
+        # set the viazen of the photo to the url viazen
+        form.instance.istoriaviazen_id = self.kwargs['pk']
+        return super().form_valid(form)
 
 
 class ViazenUpdateView(UpdateView):

--- a/map/views.py
+++ b/map/views.py
@@ -157,7 +157,7 @@ class PhotoViazenView(CreateView):
 class ViazenUpdateView(UpdateView):
     template_name = 'map/viajen_form.html'
     model = Istoriaviazen
-    fields = ['title', 'description', 'date', 'creator']
+    fields = ['title', 'description', 'date']
     success_url = reverse_lazy('home')
 
     def get_context_data(self, *args, **kwargs):

--- a/map/views.py
+++ b/map/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.core.serializers import serialize
 from django.views.generic.base import TemplateView
 from map.gps_images import ImageMetaData
-from django.views.generic.edit import FormView, CreateView, UpdateView, DeleteView
+from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from .models import Aldeia, Suco, Subdistrict, District, PhotoTimor, Istoriaviazen
 from django.contrib.gis.geos import Point
 from django.urls import reverse_lazy


### PR DESCRIPTION
- Removes the creator field from the istoria viazen forms, sets the creator to the logged in user when the create form is validly submitted
- Removes the istoria select from the add photo form