### PR TITLE
fixed width for dropdown in settings

### DIFF
--- a/map/static/css/timor.css
+++ b/map/static/css/timor.css
@@ -452,6 +452,8 @@ ul.dropdown-menu.show {
     line-height: 2;
     width: 100%;
     font-size: 12px;
+    right: 0;
+    left: auto;
 }
 
 ul.dropdown-menu.show > a li:hover {


### PR DESCRIPTION
Closes #no_issue_number 

## Description of the Problem / Feature
- Broken dropdown expand when users clicks on settings dropdown

## Explanation of the solution
- Before
![image](https://user-images.githubusercontent.com/12780301/89103675-7459ea80-d40b-11ea-9704-f00ccd28bc3b.png)

- After fix it
![image](https://user-images.githubusercontent.com/12780301/89103666-58564900-d40b-11ea-803c-2f9ad4bb506c.png)


## Instructions on making this work
- Try see on settings 
