### PR TITLE
Fixed styles of journey forms

### DIFF
--- a/map/static/css/timor.css
+++ b/map/static/css/timor.css
@@ -166,12 +166,30 @@ body .default-gray-theme {
     background-color: var(--white-2)!important;
 }
 
-h3.form-title {
-    margin-bottom: 20px;
+.col.form-title {
     width: 100%;
-    padding-bottom: 6px;
-    border-bottom: 1px solid rgb(240, 242, 245);
+    text-align: center;
+    margin: 24px;
+    margin-top: 10px;
 }
+
+.col.form-title > h3:before {
+    position: absolute;
+    content: '';
+    width: 100%;
+    left: 0;
+    top: 15px;
+    height: 1px;
+    border-top: 1px solid #31d9ff;
+}
+
+.col.form-title > h3 > span {
+    font-style: normal;
+    background: var(--white-1);
+    position: relative;
+    padding: 10px;
+}
+
 
 #mapid { 
     height: 450px; 
@@ -333,6 +351,7 @@ button.btn.btn-success.btn-lg {
 
 .btn-pull-right {
     float: right;
+    margin: 4px;
 }
 
 .row.choose-files {

--- a/map/static/css/timor.css
+++ b/map/static/css/timor.css
@@ -22,7 +22,7 @@ body {
     --black: #000000;
     --yellow-1: #FFFF00;
     --yellow-2: #d39e00;
-    --blue-1: #23aeea;
+    --blue-1: #117a8b;
     --blue-2: #007bff;
     --red-1: #c0392b;
     --red-2: #FF0000;
@@ -63,6 +63,9 @@ a:hover {
     text-decoration: none
 }
 
+label {
+    font-weight: 600;
+}
 /* STYLING FOR INPUT ELEMENTS */
 
 .white-theme textarea {
@@ -71,11 +74,25 @@ a:hover {
     background: var(--white-2);
 }
 
-input[type=text]:focus, [type=email]:focus, [name=messages]:focus {
+input[type=text]:focus, [type=email]:focus, [name=messages]:focus, textarea:not([type="submit"]):focus {
     z-index: 2;
     box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px var(--blue-2);
-    border-radius: 4px;
+    border-radius: 2px;
     position: sticky;
+}
+
+input:not([type="submit"]), textarea:not([type="submit"]) {
+    border-radius: 2px;
+    border: 1px solid #31d9ff;
+    background: #f0f2f5;
+    color: #151313;
+    width: 100%;
+    padding: 11px;
+    cursor: unset;
+}
+
+input[type="file"] {
+    cursor: pointer;
 }
 
 /* BUTTONS STYLES */
@@ -149,6 +166,13 @@ body .default-gray-theme {
     background-color: var(--white-2)!important;
 }
 
+h3.form-title {
+    margin-bottom: 20px;
+    width: 100%;
+    padding-bottom: 6px;
+    border-bottom: 1px solid rgb(240, 242, 245);
+}
+
 #mapid { 
     height: 450px; 
     margin-bottom: 30px;
@@ -168,6 +192,24 @@ span.yellow_text {
 
 span.red_text {
     color: #FF0000;
+}
+
+figure > a.top-right {
+    position: absolute;
+    top: 2px;
+    right: 18px;
+    padding: 1px 10px;
+    margin: 2px;
+    font-weight: 600;
+    background: white;
+    opacity: .6;
+    border-radius: 2px;
+    color: #bbbcbe;
+
+}
+
+figure > a.top-right:hover {
+    color: var(--black);
 }
 
 p.detail {
@@ -210,6 +252,12 @@ span.person-name {
     grid-gap: 1px;
 }
 
+.grid-gallery {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-gap: 1px;
+}
+
 /* CREATE FORM */
 
 .form-group {
@@ -232,31 +280,22 @@ select#id_creator {
     margin-bottom: 10px;
 }
 
-input#id_duration_of_trip_0 {
+input#id_duration_of_trip_0, input#id_duration_of_trip_1 {
     inline-size: auto;
-    border-radius: 5px;
     padding: 3px 22px;
-    font-size: 16px;
     color: #555;
+    display: inline-block;
+    margin: 4px;
+    max-width: 37%;
 }
 
-input#id_duration_of_trip_1 {
-    inline-size: auto;
-    border-radius: 5px;
-    padding: 3px 22px;
-    font-size: 16px;
-    color: #555;
+.select-date-trip {
+    margin-top: 10px;
     margin-bottom: 10px;
 }
 
 span.ui-icon.ui-icon-circle-triangle-w, span.ui-icon.ui-icon-circle-triangle-e {
     display: contents;
-}
-
-input#id_title {
-    border-radius: 5px;
-    padding: 3px 22px;
-    font-size: 16px;
 }
 
 input#id_image_trip {
@@ -292,6 +331,15 @@ button.btn.btn-success.btn-lg {
     font-family: auto;
 }
 
+.btn-pull-right {
+    float: right;
+}
+
+.row.choose-files {
+    margin-top: 6px;
+    margin-bottom: 16px;
+}
+
 img.gallery-img.add-pointer {
     cursor: pointer;
 }
@@ -302,6 +350,11 @@ img.gallery-img {
     border-radius: 4px;
 }
 
+img.edit-img-display {
+    max-width: 100%;
+    height: 109px;
+    border-radius: 4px;
+}
 .col-md-6.search-journey {
     line-height: 2;
 }
@@ -392,6 +445,7 @@ h3 {
     border-radius: 6px;
     margin-top: 10px;
     padding-top: 10px;
+    padding-bottom: 10px;
     width: 900px;
 }
 
@@ -475,15 +529,6 @@ ul.dropdown-menu.show > a li img {
     margin-right: 12px;
 }
 
-a:hover {
-    color: #0056b3;
-}
-
-a:hover {
-    color: #117a8b;
-    text-decoration: none;
-}
-
 .cont-modal {
     margin-top: 50px;
 }
@@ -506,7 +551,7 @@ a:hover {
 .active-users {
     background-color: rgba(0,123,255,.25);
     font-weight: 600;
-    color: #117a8b;
+    color: var(--blue-1);
     border-radius: 2px;
     padding: 6px;
 }
@@ -517,12 +562,12 @@ a:hover {
 .show-users:hover {
     background-color: #f0f2f5;
     font-weight: 600;
-    color: #117a8b;
+    color: var(--blue-1);
     border-radius: 2px;
 }
 
 .active-users > a {
-    color: #117a8b;
+    color: var(--blue-1);
 }
 
 .group-upload {
@@ -553,9 +598,5 @@ a:hover {
     color: #fff;
     background-color: #ff0019;
     border-color: #ff0019;
-}
-
-a:hover {
-    text-decoration: none;
 }
 

--- a/map/templates/map/viajen_form.html
+++ b/map/templates/map/viajen_form.html
@@ -7,11 +7,8 @@
 
 {% block container_content %}
     <div class="row">
-        <div class="col-md-12">
-            <h3 class="form-title">
-                <a href="{% url 'home' %}">&larr; {% trans 'Back' %}</a>
-                {{hatama_viazen}} {{ update_viazen }}
-            </h3>
+        <div class="col form-title">
+            <h3><span>{{ hatama_viazen }}{{ update_viazen }}</span></h3>
         </div>
     </div>
 
@@ -88,7 +85,7 @@
 
         <div class="row choose-files">
             <div class="col">
-                <input type="file" name="photos" accept="image/.jpg,.jpeg" multiple>
+                <input type="file" name="photos" accept="image/.jpeg, .jpg" multiple>
             </div>
         </div>
 
@@ -106,6 +103,7 @@
         <div class="row">
             <div class="col-12">
                 <button type="submit" class="btn btn-primary btn-pull-right">{% trans 'Save Journey' %}</button>
+                <a href='{% url "home" %}' class="btn btn-default btn-pull-right">{% trans 'Cancel' %}</a>
             </div>
         </div>
     </form>

--- a/map/templates/map/viajen_form.html
+++ b/map/templates/map/viajen_form.html
@@ -8,9 +8,8 @@
 {% block container_content %}
     <div class="row">
         <div class="col-md-12">
-            <h3 class="trip-text">
-                <a href="{% url 'home' %}">&larr; {% trans 'Back' %}
-                </a>
+            <h3 class="form-title">
+                <a href="{% url 'home' %}">&larr; {% trans 'Back' %}</a>
                 {{hatama_viazen}} {{ update_viazen }}
             </h3>
         </div>
@@ -33,7 +32,7 @@
         {% endif %}
 
         <div class="row">
-            <div class="col-6">
+            <div class="col-12">
                 {{ form.title.label_tag }}
                 {% if not form.is_bound %}
                     {% render_field form.title class="form-control" %}
@@ -49,7 +48,9 @@
                 {% endif %}
                 <small class="form-text text-muted">{{ form.title.help_text }}</small>
             </div>
-            <div class="col-6">
+        </div>
+        <div class="row">
+            <div class="col-12 select-date-trip">
                 {{ form.duration_of_trip.label_tag }}
                 {% if not form.is_bound %}
                     {% render_field form.duration_of_trip class="form-control" %}
@@ -65,44 +66,46 @@
                 {% endif %}
                 <small class="form-text text-muted">{{ form.duration_of_trip.help_text }}</small>
             </div>
-            <div class="col">
+        </div>
+        <div class="row">
+            <div class="col-12">
                 {{ form.description.label_tag }}
                 {% if not form.is_bound %}
-                    {% render_field form.description class="form-control" %}
+                    {% render_field form.description class="form-control" cols="4" rows="4" %}
                 {% elif form.description.errors %}
-                    {% render_field form.description class="form-control is-invalid" %}
+                    {% render_field form.description class="form-control is-invalid" cols="4" rows="4" %}
                     {% for error in form.description.errors %}
                     <div class="invalid-feedback">
                         {{ error }}
                     </div>
                     {% endfor %}
                 {% else %}
-                    {% render_field form.description class="form-control is-valid" %}
+                    {% render_field form.description class="form-control is-valid" cols="4" rows="4" %}
                 {% endif %}
                 <small class="form-text text-muted">{{ form.description.help_text }}</small>
             </div>
         </div>
 
-        <div class="row">
+        <div class="row choose-files">
             <div class="col">
                 <input type="file" name="photos" accept="image/.jpg,.jpeg" multiple>
             </div>
         </div>
 
+        <div class="row grid-gallery">
         {% for photo in object.photos.all %}
-        <div class="row">
-            <div class="col-3">
-                <img width="200" src="{{ photo.image.url }}">
-                <a href="{% url 'delete_photo' pk=photo.pk %}?next={{ request.path }}">
-                    <img src="{% static 'img/delete_photo.png' %}" width="25">{% trans 'Delete' %}
-                </a>
+            <div class="col-12">
+                <figure>
+                    <img class="edit-img-display" width="200" src="{{ photo.image.url }}">
+                    <a class="top-right" title="{% trans 'Delete this image' %}" href="{% url 'delete_photo' pk=photo.pk %}?next={{ request.path }}">X</a>
+                </figure>
             </div>
-        </div>
         {% endfor %}
+        </div>
 
         <div class="row">
-            <div class="col-9">
-                <button type="submit" class="btn btn-primary">{% trans 'Save Journey' %}</button>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary btn-pull-right">{% trans 'Save Journey' %}</button>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Closes #158 
Dependence PR #165 

## Description of the Problem / Feature
The edit journey and edit image now in one page, we need to tidy up the journey forms to looks nice and fix the display images in edit journey images layout.

## Explanation of the solution
- Fix images layout display on edit form to use grid layout
- Added "X" button on each images in delete form for deleting image
- Added css cursor pointer into choose file button
- Changed background color of the input fields
- Made that fields focus when user clicks on it
- Moved submit button to the right
- Removed some double CSS elements.

## Instructions on making this work
- All the changes should be checking on add and edit forms

# Note 
- Please merge this PR #165 before merge this PR.
- Those changes still not working well in device screen.
