### PR TITLE
Add an istoria api endpoint

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,10 +5,14 @@
         <div v-for="image in images" v-bind:key="image.pk" class="image_card">
             {{ image.pk }}
             <!--<img src="/media/photos/3AA92B55-4CE5-4D1B-A967-0A1D98FA45AB_FlsuDPE.jpeg" width="200"> -->
+            <img v-bind:src="'/media/' + image.images" /> 
         </div>
     </div>
     <div id="mapInset">
         <div id="mapid"></div>
+    </div>
+    <div v-for="viazen in istoriaviazen" v-bind:key="viazen.pk" class="viazen_card">
+        {{ viazen.pk }}
     </div>
 </template>
 
@@ -28,7 +32,8 @@
         ],
         data() {
             return {
-                images: []
+                images: [],
+                istoriaviazen: []
             }
         },
         methods: {
@@ -54,6 +59,13 @@
                     return response.json()
                 });
             },
+            getIstoriaviazen: function() {
+                // fetch is returning a Promise which will succeed with some geojson
+                // OR fail with an error
+                return fetch(this.urls.istoriaviazen).then(response => {
+                    return response.json()
+                });
+            },
             renderGeoJSON: function(geojson) {
                 L.geoJSON(geojson, {
                     style: function (feature) {
@@ -67,12 +79,17 @@
             renderImages: function(images) {
                 console.log(images);
                 this.images = images;
+            },
+            renderIstoriaviazen: function(istoriaviazen) {
+                console.log(istoriaviazen);
+                this.istoriaviazen = istoriaviazen;
             }
         },
         mounted() {
             this.renderMap();
             this.getGeoJSON().then(this.renderGeoJSON);
             this.getImages().then(this.renderImages);
+            this.getIstoriaviazen().then(this.renderIstoriaviazen);
         },
     }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,24 @@
 
 <template>
+    <div class="container-fluid">
     <div class="images_container">
-
         <div v-for="image in images" v-bind:key="image.pk" class="image_card">
             {{ image.pk }}
             <!--<img src="/media/photos/3AA92B55-4CE5-4D1B-A967-0A1D98FA45AB_FlsuDPE.jpeg" width="200"> -->
-            <img v-bind:src="'/media/' + image.images" /> 
         </div>
     </div>
     <div id="mapInset">
         <div id="mapid"></div>
     </div>
-    <div v-for="viazen in istoriaviazen" v-bind:key="viazen.pk" class="viazen_card">
-        {{ viazen.pk }}
+    <div v-for="viazen in istoriaviazen" class="viazen_card">
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5 class="card-title">{{ viazen.fields.title}}</h5>
+                <p class="card-text">{{ viazen.fields.description }}</p>
+                <p class="card-text"><small class="text-muted">{{ created_at }} {{ viazen.fields.created_at }}</small></p>
+            </div>
+        </div>
+    </div>
     </div>
 </template>
 
@@ -33,7 +39,8 @@
         data() {
             return {
                 images: [],
-                istoriaviazen: []
+                istoriaviazen: [],
+                created_at: "Created at :"
             }
         },
         methods: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,24 +1,24 @@
 
 <template>
     <div class="container-fluid">
-    <div class="images_container">
-        <div v-for="image in images" v-bind:key="image.pk" class="image_card">
-            {{ image.pk }}
-            <!--<img src="/media/photos/3AA92B55-4CE5-4D1B-A967-0A1D98FA45AB_FlsuDPE.jpeg" width="200"> -->
-        </div>
-    </div>
-    <div id="mapInset">
-        <div id="mapid"></div>
-    </div>
-    <div v-for="viazen in istoriaviazen" class="viazen_card">
-        <div class="card mb-3">
-            <div class="card-body">
-                <h5 class="card-title">{{ viazen.fields.title}}</h5>
-                <p class="card-text">{{ viazen.fields.description }}</p>
-                <p class="card-text"><small class="text-muted">{{ created_at }} {{ viazen.fields.created_at }}</small></p>
+        <div class="images_container">
+            <div v-for="image in images" v-bind:key="image.pk" class="image_card">
+                {{ image.pk }}
+                <!--<img src="/media/photos/3AA92B55-4CE5-4D1B-A967-0A1D98FA45AB_FlsuDPE.jpeg" width="200"> -->
             </div>
         </div>
-    </div>
+        <div id="mapInset">
+            <div id="mapid"></div>
+        </div>
+        <div v-for="viazen in istoriaviazen" v-bind:key="viazen.pk" class="viazen_card">
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h5 class="card-title">{{ viazen.fields.title}}</h5>
+                    <p class="card-text">{{ viazen.fields.description }}</p>
+                    <p class="card-text"><small class="text-muted">Created at: {{ viazen.fields.created_at }}</small></p>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -40,7 +40,6 @@
             return {
                 images: [],
                 istoriaviazen: [],
-                created_at: "Created at :"
             }
         },
         methods: {

--- a/vue_ui/urls.py
+++ b/vue_ui/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import VueView, geojson_api, images_api
+from .views import VueView, geojson_api, images_api, istoriaviazen_api
 
 urlpatterns = [
     path('', VueView.as_view(), name="home"),
     path('api/geojson', geojson_api, name="api_geojson"),
     path('api/images', images_api, name="api_images"),
+    path('api/istoriaviazen', istoriaviazen_api, name="api_istoriaviazen"),
 ]

--- a/vue_ui/views.py
+++ b/vue_ui/views.py
@@ -15,6 +15,7 @@ class VueView(TemplateView):
                 openstreetmap=settings.OPENSTREETMAP_URL,
                 geojson=reverse("api_geojson"),
                 images=reverse("api_images"),
+                istoriaviazen=reverse("api_istoriaviazen"),
             )
         }
         return context
@@ -26,5 +27,10 @@ def geojson_api(request):
 
 def images_api(request):
     json = serialize('json', PhotoTimor.objects.all())
+    response = HttpResponse(json, content_type="application/json")
+    return response
+
+def istoriaviazen_api(request):
+    json = serialize('json', IstoriaViazen.objects.all())
     response = HttpResponse(json, content_type="application/json")
     return response


### PR DESCRIPTION
Closes #181 

## Description of the Problem / Feature
- add an instoria viazen api endpoint
## Explanation of the solution
- [ ] add a view function that reurns json serialized Istoria objects
- [ ] configure the urls.py to expose it to http requests
- [ ] pass the url to that endpoint down in the main view context urls
- [ ] write a getIstoria function
- [ ] write a renderIstoria function
- [ ] create a new istoris array in the App.data ( like data.images )
- [ ] show those istoria using html bound to the vue componenet data.istoria

## Instructions on making this work
- 
